### PR TITLE
Update Go version in go-redis workflow to 1.25.x

### DIFF
--- a/.github/workflows/go-redis.yml
+++ b/.github/workflows/go-redis.yml
@@ -40,7 +40,7 @@ jobs:
         uses: redis/go-redis/.github/actions/run-tests@master
         with:
           redis-version: ${{ inputs.redis_version != 'unstable' && inputs.redis_version || '' }}
-          go-version: "1.25.x"
+          go-version: 'stable'
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
           client-libs-test-image-tag: ${{ inputs.client_test_image }}

--- a/.github/workflows/go-redis.yml
+++ b/.github/workflows/go-redis.yml
@@ -40,7 +40,7 @@ jobs:
         uses: redis/go-redis/.github/actions/run-tests@master
         with:
           redis-version: ${{ inputs.redis_version != 'unstable' && inputs.redis_version || '' }}
-          go-version: "1.24.x"
+          go-version: "1.25.x"
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
           client-libs-test-image-tag: ${{ inputs.client_test_image }}


### PR DESCRIPTION
CI was failing because otel tests in go-redis need a higher Go version