### PR TITLE
Add nightly flag

### DIFF
--- a/src/redis_release/bht/behaviours_docker.py
+++ b/src/redis_release/bht/behaviours_docker.py
@@ -38,9 +38,6 @@ class DockerBuildWorkflowInputs(ReleaseAction):
             self.workflow.inputs["run_type"] = "release"
         elif self.release_meta.tag == "unstable":
             self.workflow.inputs["run_type"] = "unstable"
-            # Set all module versions to "master" for unstable releases
-            for module in RedisModule:
-                self.workflow.inputs[f"{module.value}_version"] = "master"
         else:
             self.workflow.inputs["run_type"] = "custom"
 
@@ -51,6 +48,13 @@ class DockerBuildWorkflowInputs(ReleaseAction):
 
         if self.release_meta.is_custom_build:
             self.workflow.inputs["run_type"] = "custom"
+
+        # nightly_build enforces nightly build configuration: each module is
+        # master and run_type is set to nightly. custom_build is implied.
+        if self.release_meta.is_nightly_build:
+            self.workflow.inputs["run_type"] = "nightly"
+            for module in RedisModule:
+                self.workflow.inputs[f"{module.value}_version"] = "master"
 
         if self.release_meta.ephemeral.slack_channel_id is not None:
             self.workflow.inputs["slack_channel_id"] = (

--- a/src/redis_release/bht/conversation_helpers.py
+++ b/src/redis_release/bht/conversation_helpers.py
@@ -165,7 +165,8 @@ class ArgsHelper:
             ValueError: If invalid package names are provided in force_rebuild or only_packages.
         """
         # Determine valid packages based on custom_build mode
-        if llm_args.custom_build:
+        # (nightly_build implies custom_build).
+        if llm_args.custom_build or llm_args.nightly_build:
             valid_packages = set(custom_build_package_names(self.config))
         else:
             valid_packages = set(self.config.packages.keys())
@@ -199,6 +200,7 @@ class ArgsHelper:
             force_rebuild=llm_args.force_rebuild,
             only_packages=llm_args.only_packages,
             custom_build=llm_args.custom_build,
+            nightly_build=llm_args.nightly_build,
             module_versions=module_versions,
         )
         if self.state.slack_args:

--- a/src/redis_release/bht/state.py
+++ b/src/redis_release/bht/state.py
@@ -290,6 +290,7 @@ class ReleaseMeta(BaseModel):
     tag: Optional[str] = None
     ephemeral: ReleaseMetaEphemeral = Field(default_factory=ReleaseMetaEphemeral)
     is_custom_build: bool = False
+    is_nightly_build: bool = False
 
 
 class ReleaseState(BaseModel):

--- a/src/redis_release/bht/tree.py
+++ b/src/redis_release/bht/tree.py
@@ -553,9 +553,7 @@ async def run_tree_with_shutdown(tree: BehaviourTree, cutoff: int) -> Status:
             pass
 
     try:
-        return await async_tick_tock(
-            tree, cutoff=cutoff, shutdown_event=shutdown_event
-        )
+        return await async_tick_tock(tree, cutoff=cutoff, shutdown_event=shutdown_event)
     finally:
         # Cleanup signal handlers
         for sig in (signal.SIGINT, signal.SIGTERM):

--- a/src/redis_release/cli.py
+++ b/src/redis_release/cli.py
@@ -67,6 +67,11 @@ def release_print(
         "--custom-build",
         help="Enforce custom build mode, this will interpret release tag as a git ref (branch or tag) and use only packages supporting custom builds",
     ),
+    nightly_build: bool = typer.Option(
+        False,
+        "--nightly-build",
+        help="Enforce nightly build configuration: each module is master and run_type is set to nightly. custom_build is implied.",
+    ),
 ) -> None:
     """Print and render (using graphviz) the release behaviour tree or a specific PPA."""
     config_path = config_file or "config.yaml"
@@ -78,6 +83,7 @@ def release_print(
         force_rebuild=[],
         only_packages=only_packages or [],
         custom_build=custom_build,
+        nightly_build=nightly_build,
     )
     setup_logging()
 
@@ -154,6 +160,11 @@ def release(
         "--custom-build",
         help="Enforce custom build mode, this will interpret release tag as a git ref (branch or tag) and use only packages supporting custom builds",
     ),
+    nightly_build: bool = typer.Option(
+        False,
+        "--nightly-build",
+        help="Enforce nightly build configuration: each module is master and run_type is set to nightly. custom_build is implied.",
+    ),
     slack_token: Optional[str] = typer.Option(
         None,
         "--slack-token",
@@ -204,6 +215,7 @@ def release(
         override_state_name=override_state_name,
         module_versions=parse_module_versions(module_versions),
         custom_build=custom_build,
+        nightly_build=nightly_build,
         slack_args=SlackArgs(
             bot_token=slack_token,
             channel_id=slack_channel_id,

--- a/src/redis_release/conversation_models.py
+++ b/src/redis_release/conversation_models.py
@@ -148,6 +148,13 @@ class LLMReleaseArgs(BaseModel):
     custom_build: bool = Field(
         False, description="Whether this is a custom build (True) or a release (False)"
     )
+    nightly_build: bool = Field(
+        False,
+        description=(
+            "Enforce nightly build configuration: each module is master and "
+            "run_type is set to nightly. custom_build is implied."
+        ),
+    )
     module_versions: List[ModuleVersion] = Field(
         default_factory=list,
         description="List of module versions to use (e.g., [{'module_name': 'redisjson', 'version': '2.4.0'}])",

--- a/src/redis_release/models.py
+++ b/src/redis_release/models.py
@@ -5,7 +5,7 @@ import re
 from enum import Enum
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class WorkflowType(str, Enum):
@@ -224,6 +224,15 @@ class ReleaseArgs(BaseModel):
 
     slack_args: Optional["SlackArgs"] = None
     custom_build: bool = False
+    # nightly_build enforces nightly build configuration: each module is master
+    # and run_type is set to nightly. custom_build is implied.
+    nightly_build: bool = False
+
+    @model_validator(mode="after")
+    def _nightly_implies_custom(self) -> "ReleaseArgs":
+        if self.nightly_build:
+            self.custom_build = True
+        return self
 
 
 class SlackArgs(BaseModel):

--- a/src/redis_release/state_manager.py
+++ b/src/redis_release/state_manager.py
@@ -289,6 +289,8 @@ class StateManager:
 
             if self.args.custom_build:
                 state.meta.is_custom_build = True
+            if self.args.nightly_build:
+                state.meta.is_nightly_build = True
 
     def load(self) -> Optional[ReleaseState]:
         """Load state from storage backend."""


### PR DESCRIPTION
This fixes contradiction between unstable as a branch name and unstable as a build
Now unstable custom build would not imply using master versions for modules Introduce --nigtly-build mode which is a special custom build using nightly configuration (currently force all modules to master)

Maybe it would be better to have run_type=release|custom|nightly instead of separate flags, but I preferred not to break state complatibility