### PR TITLE
RED-198334 Bump GH Actions off Node 20

### DIFF
--- a/.github/workflows/redis_release.yml
+++ b/.github/workflows/redis_release.yml
@@ -29,16 +29,16 @@ jobs:
 
     steps:
       - name: Configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1.7.0
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_IAM_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
## Summary
RED-198334. Bump GitHub Actions still running on Node 20 ahead of the June 16, 2026 deprecation deadline.

The rest of the repo is already on Node 24; only `redis_release.yml` was still stale.

- Bump `aws-actions/configure-aws-credentials@v1.7.0` -> `@v6`
- Bump `actions/checkout@v4` -> `@v6`
- Bump `actions/setup-python@v4` -> `@v6`

## Test plan
- [ ] `redis_release.yml` workflow_dispatch run completes with the bumped actions
- [ ] OIDC credentials flow still works with `aws-actions/configure-aws-credentials@v6`