### PR TITLE
Add skip messages for version-gated package skips

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -82,6 +82,7 @@ packages:
     repo: redis-developer/redis-oss-release-automation
     ref: main
     build_workflow: homebrew-formula.yml
+    allow_custom_build: true
     build_timeout_minutes: 60
     build_inputs:
       formula_repo: redis-developer/homebrew-core

--- a/src/redis_release/bht/behaviours_cli_static.py
+++ b/src/redis_release/bht/behaviours_cli_static.py
@@ -187,6 +187,7 @@ class ClassifyCliStaticVersion(ReleaseAction):
                 self.feedback_message = (
                     f"release {self.release_version} < remote {self.remote_version}"
                 )
+                self.package_meta.ephemeral.skip_message = self.feedback_message
             if self.log_once(
                 "cli_static_version_classified",
                 self.package_meta.ephemeral.log_once_flags,

--- a/src/redis_release/bht/behaviours_homebrew.py
+++ b/src/redis_release/bht/behaviours_homebrew.py
@@ -270,6 +270,7 @@ class ClassifyHomebrewVersion(ReleaseAction):
                 self.feedback_message = (
                     f"release {self.release_version} < cask {self.cask_version}"
                 )
+                self.package_meta.ephemeral.skip_message = self.feedback_message
             if self.log_once(
                 "homebrew_version_classified",
                 self.package_meta.ephemeral.log_once_flags,

--- a/src/redis_release/bht/behaviours_rpm.py
+++ b/src/redis_release/bht/behaviours_rpm.py
@@ -113,11 +113,13 @@ class NeedToReleaseRPM(LoggingAction):
                 self.feedback_message = (
                     f"Skip release for RPM {str(self.release_version)} < 8.0"
                 )
+                self.package_meta.ephemeral.skip_message = self.feedback_message
                 result = Status.FAILURE
             else:
                 self.feedback_message = (
                     f"Need to release RPM version {str(self.release_version)}"
                 )
+                self.package_meta.ephemeral.skip_message = None
                 result = Status.SUCCESS
         else:
             self.feedback_message = "Failed to parse release version"

--- a/src/redis_release/bht/behaviours_snap.py
+++ b/src/redis_release/bht/behaviours_snap.py
@@ -283,6 +283,7 @@ class ClassifySnapVersion(ReleaseAction):
                 self.feedback_message = (
                     f"release {self.release_version} < remote {self.remote_version}"
                 )
+                self.package_meta.ephemeral.skip_message = self.feedback_message
             if self.log_once(
                 "snap_version_classified",
                 self.package_meta.ephemeral.log_once_flags,


### PR DESCRIPTION
Set skip_message on snap, homebrew-cask, cli-static, and rpm when a package is skipped for being at/below the published version (rpm: v7), so Slack shows the reason instead of a blank skip. Also enable allow_custom_build for homebrew-formula so it runs in nightly builds.